### PR TITLE
feat: improve virtual try-on and conversation agent

### DIFF
--- a/backend/src/try-on/try-on.controller.ts
+++ b/backend/src/try-on/try-on.controller.ts
@@ -21,7 +21,7 @@ import { ClerkAuthGuard } from '../auth/clerk-auth.guard';
 @UseGuards(ClerkAuthGuard)
 @ApiBearerAuth()
 export class TryOnController {
-  constructor(private readonly tryOnService: TryOnService) {}
+  constructor(private readonly tryOnService: TryOnService) { }
 
   @Post('generate')
   @HttpCode(HttpStatus.OK)

--- a/frontend/components/try-on/try-on-result-modal.tsx
+++ b/frontend/components/try-on/try-on-result-modal.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Download, X } from "lucide-react";
+import { Download } from "lucide-react";
 import { StyleItem } from "@/lib/style-api";
 import Image from "next/image";
 
@@ -38,17 +38,7 @@ export function TryOnResultModal({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="flex items-center justify-between">
-            <span>Your Virtual Try-On Result</span>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onClose}
-              className="h-8 w-8"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </DialogTitle>
+          <DialogTitle>Your Virtual Try-On Result</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-6">

--- a/python_engine/try_on_service/app/api/v1/endpoints/try_on.py
+++ b/python_engine/try_on_service/app/api/v1/endpoints/try_on.py
@@ -107,13 +107,27 @@ async def generate_try_on(try_on_request: TryOnRequest):
         
         garment_description = ' '.join(description_parts) if description_parts else "clothing item"
         
-        logger.info(f"Calling IDM-VTON with {len(clothing_image_urls)} clothing items")
+        # Map clothing category to IDM-VTON category
+        # IDM-VTON supports: upper_body, lower_body, dresses
+        first_category = first_item.category.upper() if first_item.category else ""
+        if first_category in ["TOP", "OUTERWEAR"]:
+            idm_category = "upper_body"
+        elif first_category in ["BOTTOM", "PANTS", "SHORTS", "SKIRT"]:
+            idm_category = "lower_body"
+        elif first_category in ["DRESS", "DRESSES", "FULL_BODY"]:
+            idm_category = "dresses"
+        else:
+            # Default to upper_body for unknown categories
+            idm_category = "upper_body"
+        
+        logger.info(f"Calling IDM-VTON with {len(clothing_image_urls)} clothing items, category: {idm_category}")
         
         # Generate try-on image
         image_base64 = await idm_vton_service.generate_try_on(
             user_photo_url=user_photo_url,
             clothing_image_urls=clothing_image_urls,
-            prompt=garment_description
+            prompt=garment_description,
+            category=idm_category
         )
         
         logger.info("Try-on generation successful")


### PR DESCRIPTION
Virtual Try-On:
- Switch to URL-based approach (no local file downloads)
- Remove PIL dependency for simpler deployment
- Fix duplicate X button in result modal

Conversation Agent:
- Add image context extraction for multi-turn conversations
- Users can now reference previously analyzed images
- Add prompt guideline #9 for multi-turn image context